### PR TITLE
Fix by adding manual tracking of ember login state for testing

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -7,14 +7,31 @@ export default Ember.Route.extend({
       let provider="password";
       let email = controller.get("email");
       let password = controller.get("password");
+      if (Ember.testing){
+        var waiter = (() => false);
+        Ember.Test.registerWaiter(waiter);
+      }
       this.get("session").open("firebase", { provider, email, password }).then(() => {
+        if (Ember.testing){
+          Ember.Test.unregisterWaiter(waiter);
+        }
         this.transitionTo("projects");
       }, (error) => {
+        if (Ember.testing){
+          Ember.Test.unregisterWaiter(waiter);
+        }
         controller.set("error", error);
       });
     },
     signOut() {
+      if (Ember.testing){
+        var waiter = (() => false);
+        Ember.Test.registerWaiter(waiter);
+      }
       this.get("session").close().then(() => {
+        if (Ember.testing){
+          Ember.Test.unregisterWaiter(waiter);
+        }
         this.transitionTo("signin");
       });
     }


### PR DESCRIPTION
The root cause of the error is that the ember testing system doesn't know how to handle Firebase's asynchronicity. With most adapters, this isn't a problem, because the testing system instruments AJAX calls to ensure they have completed before proceeding, but this obviously doesn't work with Firebase's websockets communication. See the [original discussion](https://github.com/firebase/emberfire/issues/312#issuecomment-152044260) for more details.

Here's one way to fix this issue, by manually wrapping the signin/out calls to ensure they complete before testing progresses. I've also submitted [a pull request](https://github.com/firebase/emberfire/pull/330) to emberfire to hopefully fix this upstream so the manual management won't be needed.
